### PR TITLE
Fix invalid README GoDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This [Go (golang)](https://golang.org) library implements parsing and serializat
 
 ## Docs
 
-[Browse the documentation on Go.dev](https://pkg.go.dev/dunglas/httpsfv).
+[Browse the documentation on Go.dev](https://pkg.go.dev/github.com/dunglas/httpsfv).
 
 ## Credits
 


### PR DESCRIPTION
Thanks for project, I'll definitely take a look at the W3 spec using this package 👍 
Just noticed the _GoDoc_ URL in the `README` is broken so I've sdded the missing `github.com` domain element.